### PR TITLE
 Added byte alignment for raw data segments

### DIFF
--- a/ld.go
+++ b/ld.go
@@ -100,12 +100,12 @@ SECTIONS {
     _{{.Name}}SegmentRomStart = _RomSize;
     ..{{.Name}} : AT(_RomSize)
     {
-			. = ALIGN(0x10);
+      . = ALIGN(0x10);
       _{{.Name}}SegmentDataStart = .;
       {{range .Includes -}}
       "{{.}}.o"
       {{end}}
-			. = ALIGN(0x10);
+      . = ALIGN(0x10);
       _{{.Name}}SegmentDataEnd = .;
     } > ram
     _RomSize += SIZEOF(..{{.Name}});

--- a/ld.go
+++ b/ld.go
@@ -100,10 +100,12 @@ SECTIONS {
     _{{.Name}}SegmentRomStart = _RomSize;
     ..{{.Name}} : AT(_RomSize)
     {
+			. = ALIGN(0x10);
       _{{.Name}}SegmentDataStart = .;
       {{range .Includes -}}
       "{{.}}.o"
       {{end}}
+			. = ALIGN(0x10);
       _{{.Name}}SegmentDataEnd = .;
     } > ram
     _RomSize += SIZEOF(..{{.Name}});


### PR DESCRIPTION
I was trying to build a rom containing multiple raw image files and noticed things not loading correctly on a real N64 system. Found the raw segments weren't aligned so I modified the linker code.

Btw thank you so much for you fantastic new linker! I added it to my UltraEd project and it was my final missing piece to running on Win 10. :0)