### PR TITLE
Fix issues with the delay slot

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -19,12 +19,13 @@ _start:
 1:
 	sw	$0, 0($8)
 	sw	$0, 4($8)
-	addi	$8, 8
 	addi	$9, 0xfff8
 	bne	$9, $0, 1b
+	addi	$8, 8
 	la	$10, {{.Entry}} + 0
 	la	$29,{{.StackInfo.Start}} + {{.StackInfo.Offset}}
 	jr	$10
+	nop
 `
 	tmpl, err := template.New("test").Parse(t)
 	if err != nil {

--- a/ld.go
+++ b/ld.go
@@ -12,7 +12,7 @@ import (
 	"text/template"
 )
 
-var ldArgs = []string{"-G 0", "-S", "-noinhibit-exec", "-nostartfiles", "-nodefaultlibs", "-nostdinc", "-M"}
+var ldArgs = []string{"-G 0", "-noinhibit-exec", "-nostartfiles", "-nodefaultlibs", "-nostdinc", "-M"}
 
 func createLdScript(w *Wave) (io.Reader, error) {
 	t := `
@@ -114,7 +114,8 @@ SECTIONS {
   /DISCARD/ :
   {
     /* Discard everything we haven't explicitly used. */
-    *(*)
+    *(.eh_frame)
+    *(.MIPS.abiflags)
   }
   _RomEnd = _RomSize;
 }


### PR DESCRIPTION
The mips processor of the N64 has what is called a delay slot for branching instructions. This means the instruction after a branch or jump will be executed, even if the branching path was taken. The reordering of the instructions here prevents `la	$10, {{.Entry}} + 0` from being run every cycle of the loop and the `nop` at the end ensure a valid statement is in the delay slot