### PR TITLE
Restore linker errors for incomplete binaries

### DIFF
--- a/ld.go
+++ b/ld.go
@@ -12,7 +12,7 @@ import (
 	"text/template"
 )
 
-var ldArgs = []string{"-G 0", "-S", "-noinhibit-exec", "-nostartfiles", "-nodefaultlibs", "-nostdinc", "-M"}
+var ldArgs = []string{"-G 0", "-S", "-nostartfiles", "-nodefaultlibs", "-nostdinc", "-M"}
 
 func createLdScript(w *Wave) (io.Reader, error) {
 	t := `

--- a/ld.go
+++ b/ld.go
@@ -70,7 +70,7 @@ SECTIONS {
       {{end}}
       . = ALIGN(0x10);
       _{{.Name}}SegmentDataEnd = .;
-    } > ram
+    } {{if (gt .Positioning.Address 0x80000400)}} > ram {{end}}
     _RomSize += (_{{.Name}}SegmentDataEnd - _{{.Name}}SegmentTextStart);
     _{{.Name}}SegmentRomEnd = _RomSize;
 
@@ -93,7 +93,7 @@ SECTIONS {
       . = ALIGN(0x10);
       _{{.Name}}SegmentBssEnd = .;
       _{{.Name}}SegmentEnd = .;
-    } > ram.bss
+    } {{if (gt .Positioning.Address 0x80000400)}} > ram.bss {{end}}
     _{{.Name}}SegmentBssSize =  _{{.Name}}SegmentBssEnd - _{{.Name}}SegmentBssStart;
   {{ end }}
   {{range .RawSegments -}}


### PR DESCRIPTION
This closes #6 by removing the noinhibit-exec flag.  As a result, some of the demos which previously built (but did not work) now complain about why they won't work.

With a modern GCC10 toolchain most of those problems were either the Kuseg zbuffer/cfb/etc. sections trying to load into Kseg0 (which @lambertjamesd fixed), or the use of functions from libgcc that is not built following some N64 homebrew guides.