### PR TITLE
Improve error messages

### DIFF
--- a/cmd/spicy/main.go
+++ b/cmd/spicy/main.go
@@ -101,6 +101,11 @@ func main() {
 	as := spicy.NewRunner(*as_command)
 	objcopy := spicy.NewRunner(*objcopy_command)
 	preprocessed, err := spicy.PreprocessSpec(f, gcc, includeFlags, defineFlags, undefineFlags)
+	
+	if err != nil {
+		panic(err)
+	}
+
 	spec, err := spicy.ParseSpec(preprocessed)
 	if err != nil {
 		panic(err)

--- a/spec.go
+++ b/spec.go
@@ -148,6 +148,7 @@ func convertSegmentAst(s *SegmentAst) (*Segment, error) {
 			replaced := strings.Replace(statement.Value.String, "$(", "$", -1)
 			replaced = strings.Replace(replaced, ")", "", -1)
 			replaced = filepath.Clean(os.ExpandEnv(replaced))
+
 			seg.Includes = append(seg.Includes, replaced)
 			break
 		case "maxsize":
@@ -202,7 +203,10 @@ func convertWaveAst(s *WaveAst, segments map[string]*Segment) (*Wave, error) {
 			break
 		case "include":
 			seg := segments[statement.Value.String]
-			if seg.Flags.Object {
+
+			if seg == nil {
+				return nil, errors.New(fmt.Sprintf("Undefined segment '%s' included in wave", statement.Value.String));
+			} else if seg.Flags.Object {
 				out.ObjectSegments = append(out.ObjectSegments, seg)
 			} else if seg.Flags.Raw {
 				out.RawSegments = append(out.RawSegments, seg)


### PR DESCRIPTION
Output preproccesor errors
Give a better error message when referencing an undefined segment