### PR TITLE
Preserve debugging symbols in intermediate elf file

### DIFF
--- a/ld.go
+++ b/ld.go
@@ -4,15 +4,16 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"math/rand"
 	"os"
 	"path/filepath"
 	"text/template"
+
+	log "github.com/sirupsen/logrus"
 )
 
-var ldArgs = []string{"-G 0", "-S", "-nostartfiles", "-nodefaultlibs", "-nostdinc", "-M"}
+var ldArgs = []string{"-G 0", "-nostartfiles", "-nodefaultlibs", "-nostdinc", "-M"}
 
 func createLdScript(w *Wave) (io.Reader, error) {
 	t := `
@@ -114,7 +115,8 @@ SECTIONS {
   /DISCARD/ :
   {
     /* Discard everything we haven't explicitly used. */
-    *(*)
+    *(.eh_frame)
+    *(.MIPS.abiflags)
   }
   _RomEnd = _RomSize;
 }


### PR DESCRIPTION
The debugging symbols get removed during the objcpy step anyway. This change preserves them in the elf file used before the final step that builds the rom. Having the debugging symbols allows debugging with GDB